### PR TITLE
Enable Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# COLLABORATE [![Build Status](https://travis-ci.org/excaliburHisSheath/collaborate.svg?branch=master)](https://travis-ci.org/excaliburHisSheath/collaborate)
+
+COLLADA document parsing for Rust.


### PR DESCRIPTION
Add a `.travis.yml` file to enable builds on [Travis](https://travis-ci.org/). Uses the default Travis configuration for Rust, which runs `cargo build` and `cargo test`. I've also setup the build to run on stable, beta, and nightly. It'll ignore failures on nightly, but that can be used to help notify the Rust team of bugs.

Also, I've added a `README.md` file with the build status badge, because badges are cool.

Travis builds for this project: https://travis-ci.org/excaliburHisSheath/collaborate