### PR TITLE
More codegen functionality

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -183,7 +183,6 @@ pub struct Unit {
     /// The name of the distance unit. For example, “meter”, “centimeter”, “inch”, or “parsec”.
     /// This can be the name of a real measurement, or an imaginary name. Defaults to `1.0`.
     #[attribute]
-    #[text_data]
     pub meter: f64,
 
     /// How many real-world meters in one distance unit as a floating-point number. For example,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub use xml::reader::{Error as XmlError, XmlEvent};
 
 use std::fmt::{self, Display, Formatter};
 use std::io::Read;
-use std::num::ParseFloatError;
+use std::num::{ParseFloatError, ParseIntError};
 use utils::{ColladaElement, StringListDisplay};
 use xml::common::Position;
 use xml::reader::EventReader;
@@ -336,6 +336,11 @@ pub enum ErrorKind {
     /// [f64::from_str]: https://doc.rust-lang.org/std/primitive.f64.html#method.from_str
     ParseFloatError(ParseFloatError),
 
+    /// A integer value was formatted incorrectly.
+    ///
+    /// Floating point values are parsed according to Rust's [standard handling for integers](https://doc.rust-lang.org/std/primitive.usize.html#method.from_str).
+    ParseIntError(ParseIntError),
+
     /// A datetime string was formatted incorrectly.
     ///
     /// Datetime strings in COLLADA are in the [ISO 8601][ISO 8601] format, and improperly
@@ -442,6 +447,12 @@ impl From<::chrono::format::ParseError> for ErrorKind {
 impl From<::std::num::ParseFloatError> for ErrorKind {
     fn from(from: ::std::num::ParseFloatError) -> ErrorKind {
         ErrorKind::ParseFloatError(from)
+    }
+}
+
+impl From<::std::num::ParseIntError> for ErrorKind {
+    fn from(from: ::std::num::ParseIntError) -> ErrorKind {
+        ErrorKind::ParseIntError(from)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,6 +489,10 @@ impl Display for ErrorKind {
                 write!(formatter, "{}", error)
             }
 
+            ErrorKind::ParseIntError(ref error) => {
+                write!(formatter, "{}", error)
+            }
+
             ErrorKind::TimeError(ref error) => {
                 write!(formatter, "{}", error)
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -60,6 +60,7 @@ pub enum ChildOccurrences {
 pub struct ElementConfiguration<'a, R: 'a + Read> {
     pub name: &'static str,
     pub children: &'a mut [ChildConfiguration<'a, R>],
+    pub text_contents: Option<&'a mut FnMut(&mut EventReader<R>, String) -> Result<()>>,
 }
 
 impl<'a, R: 'a + Read> ElementConfiguration<'a, R> {
@@ -67,6 +68,12 @@ impl<'a, R: 'a + Read> ElementConfiguration<'a, R> {
         // Keep track of the text position for the root element so that it can be used for error
         // messages.
         let root_position = reader.position();
+
+        if let Some(handle_text) = self.text_contents {
+            let contents = required_text_contents(reader, self.name)?;
+            handle_text(reader, contents)?;
+            return Ok(());
+        }
 
         // The index of the next child we are expecting.
         let mut current_child = 0;

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -210,7 +210,6 @@ pub struct Contributor {
     pub copyright: Option<String>,
 
     #[child]
-    #[text_data]
     pub source_data: Option<AnyUri>,
 }
 
@@ -267,7 +266,27 @@ pub struct Extra {
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "float_array"]
-pub struct FloatArray;
+pub struct FloatArray {
+    #[attribute]
+    pub count: usize,
+
+    #[attribute]
+    pub id: Option<String>,
+
+    #[attribute]
+    pub name: Option<String>,
+
+    #[attribute]
+    #[optional_with_default(default = "6")]
+    pub digits: usize,
+
+    #[attribute]
+    #[optional_with_default(default = "38")]
+    pub magnitude: usize,
+
+    #[text]
+    pub data: Vec<f32>,
+}
 
 /// A geometric element of unknown type.
 ///

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -145,6 +145,19 @@ impl Collada {
 }
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "accessor"]
+pub struct Accessor;
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+pub enum Array {
+    Idref(IdrefArray),
+    Name(NameArray),
+    Bool(BoolArray),
+    Float(FloatArray),
+    Int(IntArray),
+}
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "asset"]
 pub struct Asset {
     #[child]
@@ -176,6 +189,10 @@ pub struct Asset {
     #[optional_with_default]
     pub up_axis: UpAxis,
 }
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "bool_array"]
+pub struct BoolArray;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, ColladaElement)]
 #[name = "contributor"]
@@ -248,6 +265,10 @@ pub struct Extra {
     pub techniques: Vec<Technique>,
 }
 
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "float_array"]
+pub struct FloatArray;
+
 /// A geometric element of unknown type.
 ///
 /// Each variant wraps a single value containing a given type of geometric data. See the
@@ -290,6 +311,14 @@ pub struct Geometry {
     #[child]
     pub extra: Vec<Extra>,
 }
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "IDREF_array"]
+pub struct IdrefArray;
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "int_array"]
+pub struct IntArray;
 
 /// A single library of unknown type.
 ///
@@ -457,6 +486,10 @@ pub struct Mesh {
 }
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "Name_array"]
+pub struct NameArray;
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "polygons"]
 pub struct Polygons;
 
@@ -481,7 +514,32 @@ pub struct Scene;
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "source"]
-pub struct Source;
+pub struct Source {
+    #[attribute]
+    pub id: String,
+
+    #[attribute]
+    pub name: Option<String>,
+
+    #[child]
+    pub asset: Option<Asset>,
+
+    #[child]
+    pub array: Option<Array>,
+
+    #[child]
+    pub technique_common: Option<SourceTechniqueCommon>,
+
+    #[child]
+    pub techniques: Vec<Technique>,
+}
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "technique_common"]
+pub struct SourceTechniqueCommon {
+    #[child]
+    pub accessor: Accessor,
+}
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "spline"]

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -277,11 +277,11 @@ pub struct FloatArray {
     pub name: Option<String>,
 
     #[attribute]
-    #[optional_with_default(default = "6")]
+    #[optional_with_default = "6"]
     pub digits: usize,
 
     #[attribute]
-    #[optional_with_default(default = "38")]
+    #[optional_with_default = "38"]
     pub magnitude: usize,
 
     #[text]

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -197,6 +197,10 @@ pub struct Contributor {
     pub source_data: Option<AnyUri>,
 }
 
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "convex_mesh"]
+pub struct ConvexMesh;
+
 /// Provides arbitrary additional information about an element.
 ///
 /// COLLADA allows for applications to provide extra information about any given piece of data,
@@ -242,6 +246,49 @@ pub struct Extra {
     #[child]
     #[required]
     pub techniques: Vec<Technique>,
+}
+
+/// A geometric element of unknown type.
+///
+/// Each variant wraps a single value containing a given type of geometric data. See the
+/// documentation for each of the possible geometric types for more information.
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+pub enum GeometricElement {
+    ConvexMesh(ConvexMesh),
+    Mesh(Mesh),
+    Spline(Spline),
+}
+
+/// Describes the visual shape and appearance of an object in a scene.
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "geometry"]
+pub struct Geometry {
+    /// A unique identifier for the geometry instance.
+    ///
+    /// Will be unique within the document.
+    #[attribute]
+    pub id: Option<String>,
+
+    /// The human-friendly name for this geometry instance.
+    ///
+    /// Has no semantic meaning.
+    #[attribute]
+    pub name: Option<String>,
+
+    /// Metadata about this geometry instance and the data it contains.
+    #[child]
+    pub asset: Option<Asset>,
+
+    /// The actual data for the geometry instance.
+    #[child]
+    pub geometric_element: GeometricElement,
+
+    /// Arbitrary additional information about this geometry instance and the data it contains.
+    ///
+    /// For more information about 3rd-party extensions, see the
+    /// [crate-level documentation](../index.html#3rd-party-extensions).
+    #[child]
+    pub extra: Vec<Extra>,
 }
 
 /// A single library of unknown type.
@@ -363,61 +410,95 @@ pub struct LibraryPhysicsScenes;
 #[name = "library_visual_scenes"]
 pub struct LibraryVisualScenes;
 
-/// A geometric element of unknown type.
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "lines"]
+pub struct Lines;
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "linestrips"]
+pub struct Linestrips;
+
+/// Describes basic geometric meshes using vertex and primitive information.
 ///
-/// Each variant wraps a single value containing a given type of geometric data. See the
-/// documentation for each of the possible geometric types for more information.
+/// Meshes embody a general form of geometric description that primarily includes vertex and
+/// primitive information. Vertex information is the set of attributes associated with a poin on
+/// the surface of the mesh. Each vertex includes data for attributes such as:
+///
+/// * Vertex position
+/// * Vertex color
+/// * Vertex normal
+/// * Vertex texture coordinate
+///
+/// The mesh also includes a description of how the vertices are organized to form the geometric
+/// shape of the mesh. The mesh vertices are collated into geometric primitives such as polygons,
+/// triangles, or lines.
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
-pub enum GeometricElement {
-    ConvexMesh(ConvexMesh),
-    Mesh(Mesh),
-    Spline(Spline),
-}
-
-/// Describes the visual shape and appearance of an object in a scene.
-#[derive(Debug, Clone, PartialEq, ColladaElement)]
-#[name = "geometry"]
-pub struct Geometry {
-    /// A unique identifier for the geometry instance.
+#[name = "mesh"]
+pub struct Mesh {
+    /// One or more [`Source`] instances containing the raw mesh data.
     ///
-    /// Will be unique within the document.
-    #[attribute]
-    pub id: Option<String>,
-
-    /// The human-friendly name for this geometry instance.
-    ///
-    /// Has no semantic meaning.
-    #[attribute]
-    pub name: Option<String>,
-
-    /// Metadata about this geometry instance and the data it contains.
+    /// [`Source`]: ./struct.Source.html
     #[child]
-    pub asset: Option<Asset>,
+    #[required]
+    pub sources: Vec<Source>,
 
-    /// The actual data for the geometry instance.
     #[child]
-    pub geometric_element: GeometricElement,
+    pub vertices: Vertices,
+
+    #[child]
+    pub primitives: Vec<Primitive>,
 
     /// Arbitrary additional information about this geometry instance and the data it contains.
     ///
     /// For more information about 3rd-party extensions, see the
     /// [crate-level documentation](../index.html#3rd-party-extensions).
     #[child]
-    pub extra: Vec<Extra>,
+    pub extras: Vec<Extra>,
 }
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
-#[name = "convex_mesh"]
-pub struct ConvexMesh;
+#[name = "polygons"]
+pub struct Polygons;
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
-#[name = "mesh"]
-pub struct Mesh;
+#[name = "polylist"]
+pub struct Polylist;
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+pub enum Primitive {
+    Lines(Lines),
+    Linestrips(Linestrips),
+    Polygons(Polygons),
+    Polylist(Polylist),
+    Triangles(Triangles),
+    Trifans(Trifans),
+    Tristrips(Tristrips),
+}
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "scene"]
 pub struct Scene;
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "source"]
+pub struct Source;
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "spline"]
 pub struct Spline;
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "triangles"]
+pub struct Triangles;
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "trifans"]
+pub struct Trifans;
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "tristrips"]
+pub struct Tristrips;
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "vertices"]
+pub struct Vertices;

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -157,6 +157,15 @@ pub enum Array {
     Int(IntArray),
 }
 
+impl Array {
+    pub fn as_float_array(&self) -> Option<&FloatArray> {
+        match *self {
+            Array::Float(ref float_array) => Some(float_array),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "asset"]
 pub struct Asset {
@@ -299,6 +308,15 @@ pub enum GeometricElement {
     Spline(Spline),
 }
 
+impl GeometricElement {
+    pub fn as_mesh(&self) -> Option<&Mesh> {
+        match *self {
+            GeometricElement::Mesh(ref mesh) => Some(mesh),
+            _ => None,
+        }
+    }
+}
+
 /// Describes the visual shape and appearance of an object in a scene.
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "geometry"]
@@ -360,6 +378,15 @@ pub enum Library {
     PhysicsModels(LibraryPhysicsModels),
     PhysicsScenes(LibraryPhysicsScenes),
     VisualScenes(LibraryVisualScenes),
+}
+
+impl Library {
+    pub fn as_library_geometries(&self) -> Option<&LibraryGeometries> {
+        match *self {
+            Library::Geometries(ref library_geometries) => Some(library_geometries),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]

--- a/src/v1_5.rs
+++ b/src/v1_5.rs
@@ -14,11 +14,11 @@ use xml::reader::EventReader;
 pub struct Collada {
     /// The version string for the COLLADA specification used by the document.
     ///
-    /// Only "1.4.0", "1.4.1", and "1.5.0" are supported currently.
+    /// Will be "1.5.0".
     #[attribute]
     pub version: String,
 
-    // Included for completeness in parsing, not actually used.
+    /// Included for completeness in parsing, not actually used.
     #[attribute]
     pub xmlns: Option<String>,
 
@@ -33,12 +33,23 @@ pub struct Collada {
     #[child]
     pub asset: Asset,
 
+    /// The collection of libraries that bulk of the actual data contained in the document.
+    ///
+    /// Libraries can occur in any order, and there can be 0 or more libraries of any given type.
+    /// Helper methods are provided to iterate over all instances of a given library type, as well
+    /// as to extract data from all instance of a library type.
+    // TODO: Actually provide the helper methods.
     #[child]
     pub libraries: Vec<Library>,
 
+    /// Defines the scene hierarchy associated with this document.
     #[child]
     pub scene: Option<Scene>,
 
+    /// Arbitrary additional information about the document as a whole.
+    ///
+    /// For more information about 3rd-party extensions, see the
+    /// [crate-level documentation](../index.html#3rd-party-extensions).
     #[child]
     pub extras: Vec<Extra>,
 }

--- a/src/v1_5.rs
+++ b/src/v1_5.rs
@@ -247,7 +247,6 @@ pub struct Contributor {
 
     /// The URL for the author's website, if present.
     #[child]
-    #[text_data]
     pub author_website: Option<AnyUri>,
 
     /// The name of the authoring tool.
@@ -267,7 +266,6 @@ pub struct Contributor {
     /// For example, if the asset based off a file `tank.s3d`, the value might be
     /// `c:/models/tank.s3d`.
     #[child]
-    #[text_data]
     pub source_data: Option<AnyUri>,
 }
 
@@ -330,12 +328,10 @@ pub struct Extra {
 pub struct GeographicLocation {
     /// The longitude of the location. Will be in the range -180.0 to 180.0.
     #[child]
-    #[text_data]
     pub longitude: f64,
 
     /// The latitude of the location. Will be in the range -180.0 to 180.0.
     #[child]
-    #[text_data]
     pub latitude: f64,
 
     /// Specifies the altitude, either relative to global sea level or relative to ground level.

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -50,3 +50,23 @@ fn extra_whitespace() {
 
     let _ = VersionedDocument::from_str(DOCUMENT).unwrap();
 }
+
+#[test]
+fn default_attrib_value() {
+    use ::collaborate::v1_4::*;
+
+    static TEST_DOCUMENT: &'static [u8] = include_bytes!("../resources/blender_cube.dae");
+
+    let source = String::from_utf8(TEST_DOCUMENT.into()).unwrap();
+    let document = Collada::from_str(&*source).unwrap();
+    let library = document.libraries[5].as_library_geometries().unwrap();
+    let mesh = library.geometries[0].geometric_element.as_mesh().unwrap();
+    let source = &mesh.sources[0];
+    let array = source.array.as_ref().and_then(Array::as_float_array).unwrap();
+
+    // Verify that the `[optional_with_default = "XXX"]` attribute is working correctly. We know
+    // that the document doesn't declare the "digits" or "magnitude" parameter on this
+    // `<float_array>` element, so we check to see if they end up with the right default values.
+    assert_eq!(6, array.digits, "Default value for `FloatArray::digits` should be 6");
+    assert_eq!(38, array.magnitude, "Default value for `FloatArray::magnitude` should be 38");
+}

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -69,4 +69,22 @@ fn default_attrib_value() {
     // `<float_array>` element, so we check to see if they end up with the right default values.
     assert_eq!(6, array.digits, "Default value for `FloatArray::digits` should be 6");
     assert_eq!(38, array.magnitude, "Default value for `FloatArray::magnitude` should be 38");
+
+}
+
+#[test]
+fn float_array_text_contents() {
+    use ::collaborate::v1_4::*;
+
+    static TEST_DOCUMENT: &'static [u8] = include_bytes!("../resources/blender_cube.dae");
+    static EXPECTED: &'static [f32] = &[1.0, 1.0, -1.0, 1.0, -1.0, -1.0, -1.0, -0.9999998, -1.0, -0.9999997, 1.0, -1.0, 1.0, 0.9999995, 1.0, 0.9999994, -1.000001, 1.0, -1.0, -0.9999997, 1.0, -1.0, 1.0, 1.0];
+
+    let source = String::from_utf8(TEST_DOCUMENT.into()).unwrap();
+    let document = Collada::from_str(&*source).unwrap();
+    let library = document.libraries[5].as_library_geometries().unwrap();
+    let mesh = library.geometries[0].geometric_element.as_mesh().unwrap();
+    let source = &mesh.sources[0];
+    let array = source.array.as_ref().and_then(Array::as_float_array).unwrap();
+
+    assert_eq!(EXPECTED, &*array.data, "`<float_array>` contents were not parsed correctly");
 }


### PR DESCRIPTION
While working implementing more of `<library_geometries>` for `1.4.1`, I ran into a few places where we need more functionality implemented in `collaborate-derive`. I've implemented that functionality and am merging it into `master` now. This pulls in some of the partially-implemented `<library_geometries>` support.

Updates to codegen:

* Remove the `#[text_data]` attribute that was used with the `#[child]` attribute to specify that a member is represented by a one-off element containing text data. Instead, `collaborate-derive` now recognizes a number of types that don't implement `ColladaElement`, and now automatically does the right thing for those types.
* Add a new `#[text]` attribute to indicate that a `ColladaElement` will have text data instead of children. this allows for us to declare types that have both attributes and text data.
* Teach the `#[optional_with_default]` attribute to take a parameter, e.g. `#[optional_with_default = "123"]`. This allows us to specify a default value instead of using the `Default` trait impl for the type, where appropriate. If no default value is specified, the `Default` impl is still used.

Unit tests verifying this behavior have been added where appropriate.

Changes to the actual crate:

* Add a number of types that live under `<library_geometries>`, notably `Mesh` and `FloatArray`.
* For the existing enum types, I've started adding `as_foo` methods to speculatively downcast to one of the discrete variants. These methods have proven useful for writing the unit tests, and so I expect that I'll continue to use this pattern going forward.