### PR TITLE
Implement polylist parsing and iteration

### DIFF
--- a/resources/blender_cube.dae
+++ b/resources/blender_cube.dae
@@ -165,7 +165,20 @@
           <input semantic="VERTEX" source="#Cube-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#Cube-mesh-normals" offset="1"/>
           <vcount>3 3 3 3 3 3 3 3 3 3 3 3 </vcount>
-          <p>0 0 2 0 3 0 7 1 5 1 4 1 4 2 1 2 0 2 5 3 2 3 1 3 2 4 7 4 3 4 0 5 7 5 4 5 0 6 1 6 2 6 7 7 6 7 5 7 4 8 5 8 1 8 5 9 6 9 2 9 2 10 6 10 7 10 0 11 3 11 7 11</p>
+          <p>
+            0  0  2  0  3  0
+            7  1  5  1  4  1
+            4  2  1  2  0  2
+            5  3  2  3  1  3
+            2  4  7  4  3  4
+            0  5  7  5  4  5
+            0  6  1  6  2  6
+            7  7  6  7  5  7
+            4  8  5  8  1  8
+            5  9  6  9  2  9
+            2 10  6 10  7 10
+            0 11  3 11  7 11
+          </p>
         </polylist>
       </mesh>
     </geometry>

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -627,7 +627,19 @@ pub struct Scene;
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "input"]
-pub struct SharedInput;
+pub struct SharedInput {
+    #[attribute]
+    pub offset: usize,
+
+    #[attribute]
+    pub semantic: String,
+
+    #[attribute]
+    pub source: UriFragment,
+
+    #[attribute]
+    pub set: Option<usize>,
+}
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "source"]

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -572,12 +572,18 @@ pub struct Param {
 
 #[derive(Debug, Clone)]
 pub struct Polygon<'a> {
+    len: usize,
     chunks: ::std::slice::Chunks<'a, usize>,
 }
 
 impl<'a> Polygon<'a> {
     pub fn vertices(&self) -> ::std::slice::Chunks<'a, usize> {
         self.chunks.clone()
+    }
+
+    /// Returns the number of vertices in this polygon.
+    pub fn len(&self) -> usize {
+        self.len
     }
 }
 
@@ -656,6 +662,11 @@ impl Polylist {
             verts_so_far: 0,
         }
     }
+
+    /// Returns the number of polygons in the polylist.
+    pub fn len(&self) -> usize {
+        self.count
+    }
 }
 
 pub struct PolylistIter<'a> {
@@ -679,6 +690,7 @@ impl<'a> ::std::iter::Iterator for PolylistIter<'a> {
                 let indices = &primitives[self.verts_so_far * self.num_indices_per_vertex .. (self.verts_so_far + num_verts) * self.num_indices_per_vertex];
                 self.verts_so_far += num_verts;
                 Polygon {
+                    len: num_verts,
                     chunks: indices.chunks(self.num_indices_per_vertex),
                 }
             })

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -146,7 +146,24 @@ impl Collada {
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "accessor"]
-pub struct Accessor;
+pub struct Accessor {
+    #[attribute]
+    pub count: usize,
+
+    #[attribute]
+    #[optional_with_default = "0"]
+    pub offset: usize,
+
+    #[attribute]
+    pub source: AnyUri,
+
+    #[attribute]
+    #[optional_with_default = "1"]
+    pub stride: usize,
+
+    #[child]
+    pub params: Vec<Param>,
+}
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 pub enum Array {
@@ -534,6 +551,24 @@ pub struct Mesh {
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "Name_array"]
 pub struct NameArray;
+
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "param"]
+pub struct Param {
+    #[attribute]
+    pub name: Option<String>,
+
+    #[attribute]
+    pub sid: Option<String>,
+
+    #[attribute]
+    #[name = "type"]
+    pub data_type: Option<String>,
+
+    #[attribute]
+    pub semantic: Option<String>,
+}
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "polygons"]

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -570,37 +570,119 @@ pub struct Param {
     pub semantic: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct Polygon<'a> {
+    chunks: ::std::slice::Chunks<'a, usize>,
+}
+
+impl<'a> Polygon<'a> {
+    pub fn vertices(&self) -> ::std::slice::Chunks<'a, usize> {
+        self.chunks.clone()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "polygons"]
 pub struct Polygons;
 
 /// A list of polygons that are not necessarily triangles.
 ///
-/// Provides the information needed for a mesh to bind vertex attributes
-/// together and then organize those vertices into individual polygons.
+/// Provides the information needed for a mesh to bind vertex attributes together and then
+/// organize those vertices into individual polygons.
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "polylist"]
 pub struct Polylist {
+    /// A human-friendly name for this polylist.
+    ///
+    /// Has no semantic meaning.
     #[attribute]
     pub name: Option<String>,
 
+    /// The number of polygon primitives in the polylist.
     #[attribute]
     pub count: usize,
 
+    /// The name of the material associated with this polylist.
+    ///
+    /// This name is bound to a material at the time of instantiaion. See [`InstanceGeometry`]
+    /// and [`BindMaterial`].
+    ///
+    /// If `None`, then the lighting and shading results are appplication-defined.
+    ///
+    /// [`InstanceGeometry`]: ./struct.InstanceGeometry.html
+    /// [`BindMaterial`]: ./struct.BindMaterial.html
     #[attribute]
     pub material: Option<String>,
 
+    /// The input data for the polylist.
     #[child]
     pub inputs: Vec<SharedInput>,
 
+    /// A list of integers, each specifying the number of vertices for one polygon in the polylist.
     #[child]
     pub vcount: Option<VCount>,
 
+    /// A list of integers that specify the vertex attributes as indexes into the inputs.
     #[child]
     pub primitives: Option<Primitives>,
 
+    /// Arbitrary additional information about this polylist and the data it contains.
+    ///
+    /// For more information about 3rd-party extensions, see the
+    /// [crate-level documentation](../index.html#3rd-party-extensions).
     #[child]
     pub extras: Vec<Extra>,
+}
+
+impl Polylist {
+    /// Returns an iterator over the polygons in the polylist.
+    pub fn iter<'a>(&'a self) -> PolylistIter<'a> {
+        // Determine the number of indices that are used for each vertex. Generally, we expect this to
+        // be the same as the number of inputs (e.g. if there's an input for position and an input
+        // for normal, then we'd expect there to be 2 indices for each vertex), but the COLLADA spec
+        // allows multiple inputs to share an offset, effectively reducing the number of indices
+        // needed for each vertex. To account for this, we look for the largest offset used by the
+        // inputs, which should tell us consistently how many unique offsets there are.
+        // TODO: How do we handle a polylist with no inputs? Probably return no polygons.
+        let largest_offset = self.inputs.iter()
+            .map(|input| input.offset)
+            .max()
+            .unwrap();
+
+        PolylistIter {
+            polylist: self,
+            num_indices_per_vertex: largest_offset + 1,
+            vcount_iter: self.vcount.as_ref().unwrap().iter(),
+            verts_so_far: 0,
+        }
+    }
+}
+
+pub struct PolylistIter<'a> {
+    polylist: &'a Polylist,
+    num_indices_per_vertex: usize,
+    vcount_iter: ::std::slice::Iter<'a, usize>,
+    verts_so_far: usize,
+}
+
+impl<'a> ::std::iter::Iterator for PolylistIter<'a> {
+    type Item = Polygon<'a>;
+
+    fn next(&mut self) -> Option<Polygon<'a>> {
+        let primitives = match self.polylist.primitives {
+            Some(ref primitives) => primitives,
+            None => return None,
+        };
+
+        self.vcount_iter.next()
+            .map(|&num_verts| {
+                let indices = &primitives[self.verts_so_far * self.num_indices_per_vertex .. (self.verts_so_far + num_verts) * self.num_indices_per_vertex];
+                self.verts_so_far += num_verts;
+                Polygon {
+                    chunks: indices.chunks(self.num_indices_per_vertex),
+                }
+            })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
@@ -614,11 +696,26 @@ pub enum Primitive {
     Tristrips(Tristrips),
 }
 
+impl Primitive {
+    pub fn as_polylist(&self) -> Option<&Polylist> {
+        match *self {
+            Primitive::Polylist(ref polylist) => Some(polylist),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "p"]
 pub struct Primitives {
     #[text]
     data: Vec<usize>,
+}
+
+impl ::std::ops::Deref for Primitives {
+    type Target = [usize];
+
+    fn deref(&self) -> &[usize] { &*self.data }
 }
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
@@ -701,6 +798,12 @@ pub struct UnsharedInput {
 pub struct VCount {
     #[text]
     data: Vec<usize>,
+}
+
+impl ::std::ops::Deref for VCount {
+    type Target = [usize];
+
+    fn deref(&self) -> &[usize] { &*self.data }
 }
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -639,5 +639,28 @@ pub struct Trifans;
 pub struct Tristrips;
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "input"]
+pub struct UnsharedInput {
+    #[attribute]
+    pub semantic: String,
+
+    #[attribute]
+    pub source: UriFragment,
+}
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "vertices"]
-pub struct Vertices;
+pub struct Vertices {
+    #[attribute]
+    pub id: String,
+
+    #[attribute]
+    pub name: String,
+
+    #[child]
+    #[required]
+    pub inputs: Vec<UnsharedInput>,
+
+    #[child]
+    pub extras: Vec<Extra>,
+}

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -698,7 +698,7 @@ pub struct Vertices {
     pub id: String,
 
     #[attribute]
-    pub name: String,
+    pub name: Option<String>,
 
     #[child]
     #[required]

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -574,9 +574,34 @@ pub struct Param {
 #[name = "polygons"]
 pub struct Polygons;
 
+/// A list of polygons that are not necessarily triangles.
+///
+/// Provides the information needed for a mesh to bind vertex attributes
+/// together and then organize those vertices into individual polygons.
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "polylist"]
-pub struct Polylist;
+pub struct Polylist {
+    #[attribute]
+    pub name: Option<String>,
+
+    #[attribute]
+    pub count: usize,
+
+    #[attribute]
+    pub material: Option<String>,
+
+    #[child]
+    pub inputs: Vec<SharedInput>,
+
+    #[child]
+    pub vcount: Option<VCount>,
+
+    #[child]
+    pub primitives: Option<Primitives>,
+
+    #[child]
+    pub extras: Vec<Extra>,
+}
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 pub enum Primitive {
@@ -590,8 +615,19 @@ pub enum Primitive {
 }
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "p"]
+pub struct Primitives {
+    #[text]
+    data: Vec<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "scene"]
 pub struct Scene;
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "input"]
+pub struct SharedInput;
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "source"]
@@ -646,6 +682,13 @@ pub struct UnsharedInput {
 
     #[attribute]
     pub source: UriFragment,
+}
+
+#[derive(Debug, Clone, PartialEq, ColladaElement)]
+#[name = "vcount"]
+pub struct VCount {
+    #[text]
+    data: Vec<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, ColladaElement)]

--- a/tests/v1_4.rs
+++ b/tests/v1_4.rs
@@ -405,3 +405,152 @@ fn contributor_illegal_child_attribute() {
     let actual = Collada::from_str(DOCUMENT).unwrap_err();
     assert_eq!(expected, actual);
 }
+
+#[test]
+fn polylist_iter() {
+    use ::collaborate::v1_4::*;
+
+    static TEST_DOCUMENT: &'static [u8] = include_bytes!("../resources/blender_cube.dae");
+
+    let source = String::from_utf8(TEST_DOCUMENT.into()).unwrap();
+    let document = Collada::from_str(&*source).unwrap();
+    let library = document.libraries[5].as_library_geometries().unwrap();
+    let mesh = library.geometries[0].geometric_element.as_mesh().unwrap();
+    let polylist = mesh.primitives[0].as_polylist().unwrap();
+
+    let mut polygons = polylist.iter();
+
+    {
+        let polygon = polygons.next().unwrap();
+        assert_eq!(3, polygon.len());
+
+        let mut vertices = polygon.vertices();
+        assert_eq!(Some([0, 0].as_ref()), vertices.next());
+        assert_eq!(Some([2, 0].as_ref()), vertices.next());
+        assert_eq!(Some([3, 0].as_ref()), vertices.next());
+        assert_eq!(None, vertices.next());
+    }
+
+    {
+        let polygon = polygons.next().unwrap();
+        assert_eq!(3, polygon.len());
+
+        let mut vertices = polygon.vertices();
+        assert_eq!(Some([7, 1].as_ref()), vertices.next());
+        assert_eq!(Some([5, 1].as_ref()), vertices.next());
+        assert_eq!(Some([4, 1].as_ref()), vertices.next());
+        assert_eq!(None, vertices.next());
+    }
+
+    {
+        let polygon = polygons.next().unwrap();
+        assert_eq!(3, polygon.len());
+
+        let mut vertices = polygon.vertices();
+        assert_eq!(Some([4, 2].as_ref()), vertices.next());
+        assert_eq!(Some([1, 2].as_ref()), vertices.next());
+        assert_eq!(Some([0, 2].as_ref()), vertices.next());
+        assert_eq!(None, vertices.next());
+    }
+
+    {
+        let polygon = polygons.next().unwrap();
+        assert_eq!(3, polygon.len());
+
+        let mut vertices = polygon.vertices();
+        assert_eq!(Some([5, 3].as_ref()), vertices.next());
+        assert_eq!(Some([2, 3].as_ref()), vertices.next());
+        assert_eq!(Some([1, 3].as_ref()), vertices.next());
+        assert_eq!(None, vertices.next());
+    }
+
+    {
+        let polygon = polygons.next().unwrap();
+        assert_eq!(3, polygon.len());
+
+        let mut vertices = polygon.vertices();
+        assert_eq!(Some([2, 4].as_ref()), vertices.next());
+        assert_eq!(Some([7, 4].as_ref()), vertices.next());
+        assert_eq!(Some([3, 4].as_ref()), vertices.next());
+        assert_eq!(None, vertices.next());
+    }
+
+    {
+        let polygon = polygons.next().unwrap();
+        assert_eq!(3, polygon.len());
+
+        let mut vertices = polygon.vertices();
+        assert_eq!(Some([0, 5].as_ref()), vertices.next());
+        assert_eq!(Some([7, 5].as_ref()), vertices.next());
+        assert_eq!(Some([4, 5].as_ref()), vertices.next());
+        assert_eq!(None, vertices.next());
+    }
+
+    {
+        let polygon = polygons.next().unwrap();
+        assert_eq!(3, polygon.len());
+
+        let mut vertices = polygon.vertices();
+        assert_eq!(Some([0, 6].as_ref()), vertices.next());
+        assert_eq!(Some([1, 6].as_ref()), vertices.next());
+        assert_eq!(Some([2, 6].as_ref()), vertices.next());
+        assert_eq!(None, vertices.next());
+    }
+
+    {
+        let polygon = polygons.next().unwrap();
+        assert_eq!(3, polygon.len());
+
+        let mut vertices = polygon.vertices();
+        assert_eq!(Some([7, 7].as_ref()), vertices.next());
+        assert_eq!(Some([6, 7].as_ref()), vertices.next());
+        assert_eq!(Some([5, 7].as_ref()), vertices.next());
+        assert_eq!(None, vertices.next());
+    }
+
+    {
+        let polygon = polygons.next().unwrap();
+        assert_eq!(3, polygon.len());
+
+        let mut vertices = polygon.vertices();
+        assert_eq!(Some([4, 8].as_ref()), vertices.next());
+        assert_eq!(Some([5, 8].as_ref()), vertices.next());
+        assert_eq!(Some([1, 8].as_ref()), vertices.next());
+        assert_eq!(None, vertices.next());
+    }
+
+    {
+        let polygon = polygons.next().unwrap();
+        assert_eq!(3, polygon.len());
+
+        let mut vertices = polygon.vertices();
+        assert_eq!(Some([5, 9].as_ref()), vertices.next());
+        assert_eq!(Some([6, 9].as_ref()), vertices.next());
+        assert_eq!(Some([2, 9].as_ref()), vertices.next());
+        assert_eq!(None, vertices.next());
+    }
+
+    {
+        let polygon = polygons.next().unwrap();
+        assert_eq!(3, polygon.len());
+
+        let mut vertices = polygon.vertices();
+        assert_eq!(Some([2, 10].as_ref()), vertices.next());
+        assert_eq!(Some([6, 10].as_ref()), vertices.next());
+        assert_eq!(Some([7, 10].as_ref()), vertices.next());
+        assert_eq!(None, vertices.next());
+    }
+
+    {
+        let polygon = polygons.next().unwrap();
+        assert_eq!(3, polygon.len());
+
+        let mut vertices = polygon.vertices();
+        assert_eq!(Some([0, 11].as_ref()), vertices.next());
+        assert_eq!(Some([3, 11].as_ref()), vertices.next());
+        assert_eq!(Some([7, 11].as_ref()), vertices.next());
+        assert_eq!(None, vertices.next());
+    }
+
+    assert!(polygons.next().is_none());
+}


### PR DESCRIPTION
This PR fully implements parsing for the `<polylist>` element and its children. In addition, I've added iterator types that allow for users to iterate over the polygons in a polylist, and then the vertices in a polygon.

Other changes:

* Add `UriFragment` type.
* Remove the `From<String>` impl for `AnyUri`. The conversion should always be fallible since the string may not be a valid URI.