### PR TITLE
Example of extracting mesh data for a polylist

### DIFF
--- a/examples/blender_cube.rs
+++ b/examples/blender_cube.rs
@@ -4,6 +4,7 @@ use ::collaborate::v1_4::*;
 
 static TEST_DOCUMENT: &'static [u8] = include_bytes!("../resources/blender_cube.dae");
 
+#[derive(Debug, Clone)]
 struct Vertex {
     position: [f32; 3],
     normal: Option<[f32; 3]>,
@@ -29,20 +30,76 @@ fn main() {
 
             // For each of the attributes in the vertex, find the correct input and then grab
             // the vertex data.
-            for (offset, attribute) in vertex.iter().enumerate() {
+            for (offset, &attribute) in vertex.iter().enumerate() {
                 println!("offset: {}, index: {}", offset, attribute);
 
                 // TODO: Provide a helper method `inputs_for_offset` to make this less verbose.
                 // Doing so is a pain to implement without impl Trait syntax.
                 for input in polylist.inputs.iter().filter(|input| input.offset == offset) {
                     println!("{:#?}", input);
+                    // Handle the input based on its semantic.
+                    match input.semantic.as_ref() {
+                        "VERTEX" => {
+                            // The "VERTEX" semantic means that this input indexes into all of
+                            // sources specified in the `vertices` member of the host mesh.
+                            println!("VERTEX input: {:?}", input);
+                        }
+
+                        "NORMAL" => {
+                            // Find the mesh source identified by the input's `source` within the
+                            // parent `Mesh` object.
+                            let source = mesh.sources.iter()
+                                .find(|source| source.id == input.source.id())
+                                .expect("Didn't find a source with a matching ID in the parent mesh");
+
+                            // Retrieve the source's accessor and raw float array. We only support
+                            // using floats for position and normal source data, so we ignore
+                            // any other type of array source.
+                            let accessor = &source.common_accessor().expect("Source has no accessor");
+                            let array = source.array.as_ref()
+                                .and_then(Array::as_float_array)
+                                .expect("Source wasn't a float array");
+
+                            /// Use the accessor to get the normal data for the current vertex.
+                            let normal_data = accessor.access(array.data.as_ref(), attribute);
+
+                            // Use the `params` in the accesor to determine which elements in
+                            // `normal_data` correspond to the normal's X, Y, and Z components.
+                            let mut x = None;
+                            let mut y = None;
+                            let mut z = None;
+
+                            for (param, &normal_component) in accessor.params.iter().zip(normal_data.iter()) {
+                                match param.name.as_ref().map(String::as_str) {
+                                    Some("X") => { x = Some(normal_component); }
+                                    Some("Y") => { y = Some(normal_component); }
+                                    Some("Z") => { z = Some(normal_component); }
+
+                                    // Ignore any unrecognized or unsupported names.
+                                    _ => {}
+                                }
+                            }
+
+                            normal = Some([
+                                x.expect("Normal had no X component"),
+                                y.expect("Normal had no Y component"),
+                                z.expect("Normal had no Z component"),
+                            ])
+                        }
+
+                        // Ignore any unknown semantics.
+                        semantic @ _ => { println!("Ignoring unknown semantic {:?}", semantic); }
+                    }
                 }
             }
 
+            println!("Normal {:?}", normal);
             vertices.push(Vertex {
                 position: position.expect("Vertex had no position input"),
                 normal,
-            })
+            });
         }
+
+        println!("Vertices in polygon: {:#?}", vertices);
     }
 }

--- a/examples/blender_cube.rs
+++ b/examples/blender_cube.rs
@@ -58,8 +58,7 @@ fn main() {
 
                             // Find the mesh source identified by the input's `source` within the
                             // parent `Mesh` object.
-                            let source = mesh.sources.iter()
-                                .find(|source| source.id == input.source.id())
+                            let source = mesh.find_source(input.source.id())
                                 .expect("Didn't find a source with a matching ID in the parent mesh");
 
                             // Retrieve the source's accessor and raw float array. We only support
@@ -100,8 +99,7 @@ fn main() {
                         "NORMAL" => {
                             // Find the mesh source identified by the input's `source` within the
                             // parent `Mesh` object.
-                            let source = mesh.sources.iter()
-                                .find(|source| source.id == input.source.id())
+                            let source = mesh.find_source(input.source.id())
                                 .expect("Didn't find a source with a matching ID in the parent mesh");
 
                             // Retrieve the source's accessor and raw float array. We only support

--- a/examples/blender_cube.rs
+++ b/examples/blender_cube.rs
@@ -32,9 +32,9 @@ fn main() {
             // For each of the attributes in the vertex, find the correct input and then grab
             // the vertex data.
             for attribute in vertex {
-                // TODO: Provide a helper method `inputs_for_offset` to make this less verbose.
-                // Doing so is a pain to implement without impl Trait syntax.
-                for input in polylist.inputs.iter().filter(|input| input.offset == attribute.offset) {
+
+                // Retrieve the raw data for each attribute that matches the attribute's offset.
+                for input in polylist.inputs_for_offset(attribute.offset) {
                     // Handle the input based on its semantic.
                     match input.semantic.as_ref() {
                         "VERTEX" => {

--- a/examples/blender_cube.rs
+++ b/examples/blender_cube.rs
@@ -22,27 +22,81 @@ fn main() {
     let mesh = library.geometries[0].geometric_element.as_mesh().unwrap();
     let polylist = mesh.primitives[0].as_polylist().unwrap();
 
+    let mut result_polygons = Vec::new();
     for polygon in polylist {
-        let mut vertices = Vec::new();
+        let mut result_vertices = Vec::new();
         for vertex in &polygon {
             let mut position = None;
             let mut normal = None;
 
             // For each of the attributes in the vertex, find the correct input and then grab
             // the vertex data.
-            for (offset, &attribute) in vertex.iter().enumerate() {
-                println!("offset: {}, index: {}", offset, attribute);
-
+            // TODO: Should the vetex iter also specify the offset of each attribute? You always
+            // need that info, as far as I can tell.
+            for (offset, &attribute_index) in vertex.iter().enumerate() {
                 // TODO: Provide a helper method `inputs_for_offset` to make this less verbose.
                 // Doing so is a pain to implement without impl Trait syntax.
                 for input in polylist.inputs.iter().filter(|input| input.offset == offset) {
-                    println!("{:#?}", input);
                     // Handle the input based on its semantic.
                     match input.semantic.as_ref() {
                         "VERTEX" => {
                             // The "VERTEX" semantic means that this input indexes into all of
                             // sources specified in the `vertices` member of the host mesh.
-                            println!("VERTEX input: {:?}", input);
+
+                            // We're assuming that the input refers to the mesh's `vertices`
+                            // member. If that assumption is incorrect, we're going to produce
+                            // the wrong mesh data.
+                            assert_eq!(
+                                mesh.vertices.id,
+                                input.source.id(),
+                                "Input targets a `Vertices` that doesn't belong to same mesh",
+                            );
+
+                            // Find the input that corresponds to the "POSITION" semantic. The
+                            // COLLADA spec requires that there be one in a `<vertices>` element.
+                            let input = mesh.vertices.inputs.iter()
+                                .find(|input| input.semantic == "POSITION")
+                                .expect("Vertices had no input with the \"POSITION\" semantic");
+
+                            // Find the mesh source identified by the input's `source` within the
+                            // parent `Mesh` object.
+                            let source = mesh.sources.iter()
+                                .find(|source| source.id == input.source.id())
+                                .expect("Didn't find a source with a matching ID in the parent mesh");
+
+                            // Retrieve the source's accessor and raw float array. We only support
+                            // using floats for position and normal source data, so we ignore
+                            // any other type of array source.
+                            let accessor = &source.common_accessor().expect("Source has no accessor");
+                            let array = source.array.as_ref()
+                                .and_then(Array::as_float_array)
+                                .expect("Source wasn't a float array");
+
+                            /// Use the accessor to get the position data for the current vertex.
+                            let position_data = accessor.access(array.data.as_ref(), attribute_index);
+
+                            // Use the `params` in the accesor to determine which elements in
+                            // `normal_data` correspond to the normal's X, Y, and Z components.
+                            let mut x = None;
+                            let mut y = None;
+                            let mut z = None;
+
+                            for (param, &position_component) in accessor.params.iter().zip(position_data.iter()) {
+                                match param.name.as_ref().map(String::as_str) {
+                                    Some("X") => { x = Some(position_component); }
+                                    Some("Y") => { y = Some(position_component); }
+                                    Some("Z") => { z = Some(position_component); }
+
+                                    // Ignore any unrecognized or unsupported names.
+                                    _ => {}
+                                }
+                            }
+
+                            position = Some([
+                                x.expect("Normal had no X component"),
+                                y.expect("Normal had no Y component"),
+                                z.expect("Normal had no Z component"),
+                            ])
                         }
 
                         "NORMAL" => {
@@ -61,7 +115,7 @@ fn main() {
                                 .expect("Source wasn't a float array");
 
                             /// Use the accessor to get the normal data for the current vertex.
-                            let normal_data = accessor.access(array.data.as_ref(), attribute);
+                            let normal_data = accessor.access(array.data.as_ref(), attribute_index);
 
                             // Use the `params` in the accesor to determine which elements in
                             // `normal_data` correspond to the normal's X, Y, and Z components.
@@ -93,13 +147,14 @@ fn main() {
                 }
             }
 
-            println!("Normal {:?}", normal);
-            vertices.push(Vertex {
+            result_vertices.push(Vertex {
                 position: position.expect("Vertex had no position input"),
                 normal,
             });
         }
 
-        println!("Vertices in polygon: {:#?}", vertices);
+        result_polygons.push(result_vertices);
     }
+
+    println!("Resulting mesh: {:?}", result_polygons);
 }

--- a/examples/blender_cube.rs
+++ b/examples/blender_cube.rs
@@ -31,12 +31,10 @@ fn main() {
 
             // For each of the attributes in the vertex, find the correct input and then grab
             // the vertex data.
-            // TODO: Should the vetex iter also specify the offset of each attribute? You always
-            // need that info, as far as I can tell.
-            for (offset, &attribute_index) in vertex.iter().enumerate() {
+            for attribute in vertex {
                 // TODO: Provide a helper method `inputs_for_offset` to make this less verbose.
                 // Doing so is a pain to implement without impl Trait syntax.
-                for input in polylist.inputs.iter().filter(|input| input.offset == offset) {
+                for input in polylist.inputs.iter().filter(|input| input.offset == attribute.offset) {
                     // Handle the input based on its semantic.
                     match input.semantic.as_ref() {
                         "VERTEX" => {
@@ -73,7 +71,7 @@ fn main() {
                                 .expect("Source wasn't a float array");
 
                             /// Use the accessor to get the position data for the current vertex.
-                            let position_data = accessor.access(array.data.as_ref(), attribute_index);
+                            let position_data = accessor.access(array.data.as_ref(), attribute.index);
 
                             // Use the `params` in the accesor to determine which elements in
                             // `normal_data` correspond to the normal's X, Y, and Z components.
@@ -115,7 +113,7 @@ fn main() {
                                 .expect("Source wasn't a float array");
 
                             /// Use the accessor to get the normal data for the current vertex.
-                            let normal_data = accessor.access(array.data.as_ref(), attribute_index);
+                            let normal_data = accessor.access(array.data.as_ref(), attribute.index);
 
                             // Use the `params` in the accesor to determine which elements in
                             // `normal_data` correspond to the normal's X, Y, and Z components.

--- a/examples/blender_cube.rs
+++ b/examples/blender_cube.rs
@@ -1,0 +1,48 @@
+extern crate collaborate;
+
+use ::collaborate::v1_4::*;
+
+static TEST_DOCUMENT: &'static [u8] = include_bytes!("../resources/blender_cube.dae");
+
+struct Vertex {
+    position: [f32; 3],
+    normal: Option<[f32; 3]>,
+}
+
+fn main() {
+    // Load the COLLADA document from the source string.
+    let source = String::from_utf8(TEST_DOCUMENT.into()).unwrap();
+    let document = Collada::from_str(&*source).unwrap();
+
+    // Grab the `<library_geometries>` instance.
+    let library = document.libraries[5].as_library_geometries().unwrap();
+
+    // Get the `<mesh>` instance and put together the mesh data.
+    let mesh = library.geometries[0].geometric_element.as_mesh().unwrap();
+    let polylist = mesh.primitives[0].as_polylist().unwrap();
+
+    for polygon in polylist {
+        let mut vertices = Vec::new();
+        for vertex in &polygon {
+            let mut position = None;
+            let mut normal = None;
+
+            // For each of the attributes in the vertex, find the correct input and then grab
+            // the vertex data.
+            for (offset, attribute) in vertex.iter().enumerate() {
+                println!("offset: {}, index: {}", offset, attribute);
+
+                // TODO: Provide a helper method `inputs_for_offset` to make this less verbose.
+                // Doing so is a pain to implement without impl Trait syntax.
+                for input in polylist.inputs.iter().filter(|input| input.offset == offset) {
+                    println!("{:#?}", input);
+                }
+            }
+
+            vertices.push(Vertex {
+                position: position.expect("Vertex had no position input"),
+                normal,
+            })
+        }
+    }
+}

--- a/resources/blender_cube.dae
+++ b/resources/blender_cube.dae
@@ -149,7 +149,20 @@
           </technique_common>
         </source>
         <source id="Cube-mesh-normals">
-          <float_array id="Cube-mesh-normals-array" count="36">0 0 -1 0 0 1 1 0 -2.38419e-7 0 -1 -4.76837e-7 -1 2.38419e-7 -1.49012e-7 2.68221e-7 1 2.38419e-7 0 0 -1 0 0 1 1 -5.96046e-7 3.27825e-7 -4.76837e-7 -1 0 -1 2.38419e-7 -1.19209e-7 2.08616e-7 1 0</float_array>
+          <float_array id="Cube-mesh-normals-array" count="36">
+            0 0 -1
+            0 0 1
+            1 0 -2.38419e-7
+            0 -1 -4.76837e-7
+            -1 2.38419e-7 -1.49012e-7
+            2.68221e-7 1 2.38419e-7
+            0 0 -1
+            0 0 1
+            1 -5.96046e-7 3.27825e-7
+            -4.76837e-7 -1 0
+            -1 2.38419e-7 -1.19209e-7
+            2.08616e-7 1 0
+          </float_array>
           <technique_common>
             <accessor source="#Cube-mesh-normals-array" count="12" stride="3">
               <param name="X" type="float"/>

--- a/src/common.rs
+++ b/src/common.rs
@@ -265,14 +265,44 @@ impl Default for UpAxis {
     fn default() -> UpAxis { UpAxis::Y }
 }
 
+/// Represents the final fragment portion of a URI.
+///
+/// Within the COLLADA spec, URI fragments are often used to allow one element to reference
+/// another element by its ID. You can use the [`id`] method to get the ID of the targeted
+/// element.
+///
+/// [`id`]: #method.id
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UriFragment(String);
 
-// TODO: Actually parse the string and verify that it's a valid URI fragment.
-impl ::std::str::FromStr for UriFragment {
-    type Err = ::std::string::ParseError;
+impl UriFragment {
+    /// Returns the ID that this fragment targets.
+    pub fn id(&self) -> &str { self.0.as_ref() }
+}
 
-    fn from_str(string: &str) -> ::std::result::Result<UriFragment, ::std::string::ParseError> {
-        Ok(UriFragment(string.into()))
+impl ::std::str::FromStr for UriFragment {
+    type Err = UriFragmentParseError;
+
+    fn from_str(string: &str) -> ::std::result::Result<UriFragment, Self::Err> {
+        if !string.starts_with("#") {
+            return Err(UriFragmentParseError);
+        }
+
+        Ok(UriFragment(string[1..].into()))
+    }
+}
+
+/// An error when parsing a [`UriFragment`].
+///
+/// The only way that parsing a [`UriFragment`] from a string can fail is if the string doesn't
+/// begin with "#". Since there is only one way to fail, this type carries no other information.
+///
+/// [`UriFragment`]: ./struct.UriFragment.html
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UriFragmentParseError;
+
+impl ::std::fmt::Display for UriFragmentParseError {
+    fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
+        write!(formatter, "URI fragment did not start with a leading \"#\"")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ extern crate xml;
 pub use xml::common::TextPosition;
 pub use xml::reader::{Error as XmlError, XmlEvent};
 
+use common::UriFragmentParseError;
 use std::fmt::{self, Display, Formatter};
 use std::io::Read;
 use std::num::{ParseFloatError, ParseIntError};
@@ -432,6 +433,9 @@ pub enum ErrorKind {
         version: String,
     },
 
+    /// There was an invalid URI fragment in the document.
+    UriFragmentParseError(UriFragmentParseError),
+
     /// The XML in the document was malformed in some way.
     ///
     /// Not much more to say about this one ¯\_(ツ)_/¯
@@ -462,6 +466,12 @@ impl From<::std::string::ParseError> for ErrorKind {
     }
 }
 
+impl From<UriFragmentParseError> for ErrorKind {
+    fn from(from: UriFragmentParseError) -> ErrorKind {
+        ErrorKind::UriFragmentParseError(from)
+    }
+}
+
 impl Display for ErrorKind {
     fn fmt(&self, formatter: &mut Formatter) -> ::std::result::Result<(), fmt::Error> {
         match *self {
@@ -486,15 +496,15 @@ impl Display for ErrorKind {
             }
 
             ErrorKind::ParseFloatError(ref error) => {
-                write!(formatter, "{}", error)
+                error.fmt(formatter)
             }
 
             ErrorKind::ParseIntError(ref error) => {
-                write!(formatter, "{}", error)
+                error.fmt(formatter)
             }
 
             ErrorKind::TimeError(ref error) => {
-                write!(formatter, "{}", error)
+                error.fmt(formatter)
             }
 
             ErrorKind::UnexpectedAttribute { ref element, ref attribute, ref expected } => {
@@ -531,6 +541,10 @@ impl Display for ErrorKind {
 
             ErrorKind::UnsupportedVersion { ref version } => {
                 write!(formatter, "Unsupported COLLADA version {:?}, supported versions are \"1.4.0\", \"1.4.1\", \"1.5.0\"", version)
+            }
+
+            ErrorKind::UriFragmentParseError(ref error) => {
+                error.fmt(formatter)
             }
 
             ErrorKind::XmlError(ref error) => {

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -1195,9 +1195,23 @@ impl<'a> ::std::iter::IntoIterator for &'a Vertex<'a> {
     fn into_iter(self) -> VertexIter<'a> { self.iter() }
 }
 
+/// Represents a single attribute of a vertex.
+///
+/// A vertex attribute has two properties:
+///
+/// * An offset, used to determine which input(s) this attribute references.
+/// * An index, which is used to index into the data specified by the referenced input.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VertexAttribute {
+    /// The index within the relevant source array which has this attribute's value.
     pub index: usize,
+
+    /// The offset of the attribute.
+    ///
+    /// This value will match the `offset` member of one or more inputs ([`SharedInput`] or
+    /// [`UnsharedInput`]). If the attribute matches more than one input, then the attribute
+    /// indexes into all of the inputs it matches. Therefore, a single `VertexAttribute` can
+    /// map to multiple actual vertex attributes.
     pub offset: usize,
 }
 

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -954,6 +954,34 @@ pub struct Scene;
 /// consumer. This is an optimization that reduces the total number of indexes that the consumer
 /// must store. These inputs are described in this section as shared inputs but otherwise
 /// operate in the same manner as unshared inputs.
+///
+/// # Common Semantics
+///
+/// | Value of `semantic` | Description                                                |
+/// | ------------------- | ---------------------------------------------------------- |
+/// | `"BINORMAL"`        | Geometric binormal (bitangent) vector.                     |
+/// | `"COLOR"`           | Color coordinate vector. Color inputs are RGB.             |
+/// | `"CONTINUITY"`      | Continuity constraint at the control vertex (CV). See also "Curve Interpolation" in Chapter 4 of the COLLADA spec.    |
+/// | `"IMAGE"`           | Raster or MIP-level input.                                 |
+/// | `"INPUT"`           | Sampler input. See also "Curve Interpolation" in Chapter 4 of the COLLADA spec. |
+/// | `"IN_TANGENT"`      | Tangent vector for preceding control point. See also "Curve Interpolation" in Chapter 4 of the COLLADA spec. |
+/// | `"INTERPOLATION"`   | Sampler interpolation type. See also "Curve Interpolation" in Chapter 4 of the COLLADA spec. |
+/// | `"INV_BIND_MATRIX"` | Inverse of location-to-world matrix.                       |
+/// | `"JOIN"`            | Skin influence identifier.                                 |
+/// | `"LINEAR_STEPS"`    | Number of piece-wise linear approximation steps to use for the spline segment that follows this CV. See also "Curve Interpolation" in Chapter 4 of the COLLADA spec. |
+/// | `"MORPH_TARGET"`    | Morph targets for mesh morphing.                           |
+/// | `"MORPH_WEIGHT"`    | Weights for mesh morphing.                                 |
+/// | `"NORMAL"`          | Normal vector.                                             |
+/// | `"OUTPUT"`          | Sampler output. See also "Curve Interpolation" in Chapter 4 of the COLLADA spec. |
+/// | `"OUT_TANGENT"`     | Tangent vector for succeeding control point. See also "Curve Interpolation" in Chapter 4 fo the COLLADA spec. |
+/// | `"POSITION"`        | Geometric coordinate vector. See also "Curve Interpolation" in Chapter 4 of the COLLADA spec. |
+/// | `"TANGENT"`         | Geometric tangent vector.                                  |
+/// | `"TEXBINORMAL"`     | Texture binormal (bitangent) vector.                       |
+/// | `"TEXCOORD"`        | Texture coordinate vector.                                 |
+/// | `"TEXTANGENT"`      | Texture tangent vector.                                    |
+/// | `"UV"`              | Generic parameter vector.                                  |
+/// | `"VERTEX"`          | Mesh vertex.                                               |
+/// | `"WEIGHT"`          | Skin influence weighting value.                            |
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "input"]
 pub struct SharedInput {
@@ -967,7 +995,7 @@ pub struct SharedInput {
 
     /// The user-defined meaning of the input connnection.
     ///
-    /// See the type-level documentation for a list of common semantic values.
+    /// See the type-level documentation for a [list of common semantic values](#common-semantics).
     #[attribute]
     pub semantic: String,
 

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -947,6 +947,10 @@ pub struct Vertex<'a> {
     attributes: &'a [usize],
 }
 
+/// Declares the attributes and identity of mesh-vertices.
+///
+/// Mesh-vertices represent the position (identity) of the vertices comprising the mesh and other
+/// that are invariant to tessellation.
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "vertices"]
 pub struct Vertices {

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -708,6 +708,27 @@ pub struct Mesh {
     pub extras: Vec<Extra>,
 }
 
+impl Mesh {
+    /// Returns the source which matches `id`, or `None` if no sources match.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![allow(unused_variables)]
+    /// # use std::fs::File;
+    /// # use collaborate::v1_4::Collada;
+    /// # let file = File::open("resources/blender_cube.dae").unwrap();
+    /// # let document = Collada::read(file).unwrap();
+    /// # let library = document.libraries[5].as_library_geometries().unwrap();
+    /// let mesh = library.geometries[0].geometric_element.as_mesh().unwrap();
+    /// let positions_source = mesh.find_source("Cube-mesh-positions");
+    /// assert!(positions_source.is_some());
+    /// ```
+    pub fn find_source<'a>(&'a self, id: &str) -> Option<&'a Source> {
+        self.sources.iter().find(|source| source.id == id)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "Name_array"]
 pub struct NameArray;

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -358,6 +358,36 @@ impl GeometricElement {
 }
 
 /// Describes the visual shape and appearance of an object in a scene.
+///
+/// The primary purpose of `Geometry` is to provide access to a [`GeometricElement`], via its
+/// `geographic_element` member. It contains miscellaneous additional data, such as asset
+/// metadata, but otherwise does not directly contain any geometric data.
+///
+/// # Examples
+///
+/// ```
+/// # use ::collaborate::v1_4::*;
+/// # static TEST_DOCUMENT: &'static [u8] = include_bytes!("../resources/blender_cube.dae");
+/// # let source = String::from_utf8(TEST_DOCUMENT.into()).unwrap();
+/// # let document = Collada::from_str(&*source).unwrap();
+/// # let library_geometries = document.libraries[5].as_library_geometries().unwrap();
+/// let geometry = &library_geometries.geometries[0];
+/// match geometry.geometric_element {
+///     GeometricElement::ConvexMesh(ref mesh) => {
+///         // Do something with `mesh`.
+///     }
+///
+///     GeometricElement::Mesh(ref mesh) => {
+///         // Do something with `mesh`.
+///     }
+///
+///     GeometricElement::Spline(ref spline) => {
+///         // Do something with `spline`.
+///     }
+/// }
+/// ```
+///
+/// [`GeometricElement`]: ./enum.GeometricElement.html
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "geometry"]
 pub struct Geometry {

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -659,14 +659,24 @@ pub struct Linestrips;
 pub struct Mesh {
     /// One or more [`Source`] instances containing the raw mesh data.
     ///
+    /// These contain the raw data used to specify the vertex attributes of the vertices in the
+    /// mesh. The primitives in `primitives` will index into these sources to specify the mesh.
+    ///
     /// [`Source`]: ./struct.Source.html
     #[child]
     #[required]
     pub sources: Vec<Source>,
 
+    /// Describes the mesh's vertex attributes.
+    ///
+    /// `vertices` will have the [`UnsharedInput`] which specifies the "POSITION" attribute for
+    /// the mesh's vertices. It may also specify other mesh attributes.
+    ///
+    /// [`UnsharedInput`]: ./struct.UnsharedInput.html
     #[child]
     pub vertices: Vertices,
 
+    /// Geometric primitives that assemble values from the inputs into vertex attribute data.
     #[child]
     pub primitives: Vec<Primitive>,
 

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -1114,20 +1114,29 @@ pub struct Vertex<'a> {
 /// Declares the attributes and identity of mesh-vertices.
 ///
 /// Mesh-vertices represent the position (identity) of the vertices comprising the mesh and other
-/// that are invariant to tessellation.
+/// vertex attributes that are invariant to tessellation.
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "vertices"]
 pub struct Vertices {
+    /// A unique identifier of the vertices instance.
+    ///
+    /// This value is unique within the document.
     #[attribute]
     pub id: String,
 
+    /// The name of the vertices instance.
     #[attribute]
     pub name: Option<String>,
 
+    /// The input data for the vertices.
+    ///
+    /// There will be at least one element in `inputs`, and one input will specify the
+    /// `"POSITION"` semantic.
     #[child]
     #[required]
     pub inputs: Vec<UnsharedInput>,
 
+    /// Arbitrary additional data about the vertices.
     #[child]
     pub extras: Vec<Extra>,
 }

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -1036,12 +1036,31 @@ pub struct Trifans;
 #[name = "tristrips"]
 pub struct Tristrips;
 
+/// Declares the input semantic of a data source and connects a consumer of that source.
+///
+/// Declares the input connection to a data source that a consumer requires. A data
+/// source is a container of raw data that lacks semantic meaning, so that the data can be
+/// reused within the document. To use the data, a consumer declares a connection to it with the
+/// desired semantic information.
+///
+/// In COLLADA, all inputs are driven by index values. A consumer samples an input by supplying
+/// an index value to an input. Some consumers have multiple inputs that can share the same index
+/// values. Inputs that have the same `offset` value are driven by the same index value from the
+/// consumer. This is an optimization that reduces the total number of indexes that the consumer
+/// must store. These inputs are described in this section as shared inputs but otherwise
+/// operate in the same manner as unshared inputs.
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "input"]
 pub struct UnsharedInput {
+    /// The user-defined meaning of the input connnection.
+    ///
+    /// See [`SharedInput`] for a list of common semantic values.
+    ///
+    /// [`SharedInput`]: ./struct.SharedInput.html
     #[attribute]
     pub semantic: String,
 
+    /// The location of the data source.
     #[attribute]
     pub source: UriFragment,
 }

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -349,9 +349,86 @@ pub enum GeometricElement {
 }
 
 impl GeometricElement {
+    /// Attempts to downcast the geometric element to a [`ConvexMesh`].
+    ///
+    /// Returns a reference to the inner [`ConvexMesh`] if there is one, returns `None` otherwise.
+    /// This is useful if you have a `GeometricElement` but only want to use it if it represents a
+    /// [`ConvexMesh`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ::collaborate::v1_4::*;
+    /// # static TEST_DOCUMENT: &'static [u8] = include_bytes!("../resources/blender_cube.dae");
+    /// # let source = String::from_utf8(TEST_DOCUMENT.into()).unwrap();
+    /// # let document = Collada::from_str(&*source).unwrap();
+    /// # let library_geometries = document.libraries[5].as_library_geometries().unwrap();
+    /// let geometry = &library_geometries.geometries[0];
+    /// if let Some(mesh) = geometry.geometric_element.as_convex_mesh() {
+    ///     // Do something with `mesh`.
+    /// }
+    /// ```
+    ///
+    /// [`ConvexMesh`]: ./struct.ConvexMesh.html
+    pub fn as_convex_mesh(&self) -> Option<&ConvexMesh> {
+        match *self {
+            GeometricElement::ConvexMesh(ref mesh) => Some(mesh),
+            _ => None,
+        }
+    }
+
+    /// Attempts to downcast the geometric element to a [`Mesh`].
+    ///
+    /// Returns a reference to the inner [`Mesh`] if there is one, returns `None` otherwise. This
+    /// is useful if you have a `GeometricElement` but only want to use it if it represents a
+    /// [`Mesh`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ::collaborate::v1_4::*;
+    /// # static TEST_DOCUMENT: &'static [u8] = include_bytes!("../resources/blender_cube.dae");
+    /// # let source = String::from_utf8(TEST_DOCUMENT.into()).unwrap();
+    /// # let document = Collada::from_str(&*source).unwrap();
+    /// # let library_geometries = document.libraries[5].as_library_geometries().unwrap();
+    /// let geometry = &library_geometries.geometries[0];
+    /// if let Some(mesh) = geometry.geometric_element.as_mesh() {
+    ///     // Do something with `mesh`.
+    /// }
+    /// ```
+    ///
+    /// [`Mesh`]: ./struct.Mesh.html
     pub fn as_mesh(&self) -> Option<&Mesh> {
         match *self {
             GeometricElement::Mesh(ref mesh) => Some(mesh),
+            _ => None,
+        }
+    }
+
+    /// Attempts to downcast the geometric element to a [`Spline`].
+    ///
+    /// Returns a reference to the inner [`Spline`] if there is one, returns `None` otherwise. This
+    /// is useful if you have a `GeometricElement` but only want to use it if it represents a
+    /// [`Spline`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ::collaborate::v1_4::*;
+    /// # static TEST_DOCUMENT: &'static [u8] = include_bytes!("../resources/blender_cube.dae");
+    /// # let source = String::from_utf8(TEST_DOCUMENT.into()).unwrap();
+    /// # let document = Collada::from_str(&*source).unwrap();
+    /// # let library_geometries = document.libraries[5].as_library_geometries().unwrap();
+    /// let geometry = &library_geometries.geometries[0];
+    /// if let Some(spline) = geometry.geometric_element.as_spline() {
+    ///     // Do something with `spline`.
+    /// }
+    /// ```
+    ///
+    /// [`Spline`]: ./struct.Spline.html
+    pub fn as_spline(&self) -> Option<&Spline> {
+        match *self {
+            GeometricElement::Spline(ref mesh) => Some(mesh),
             _ => None,
         }
     }

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -1121,7 +1121,7 @@ impl ::std::ops::Deref for VCount {
 /// A single vertex in a polygon.
 ///
 /// A vertex is composed of one or more attributes. You can use `Vertex` to iterate over a list
-/// of [`VertexAttribute`] objects representing the attributes.
+/// of [`VertexAttribute`] objects representing the attributes of the vertex.
 ///
 /// # Examples
 ///
@@ -1154,6 +1154,25 @@ pub struct Vertex<'a> {
 }
 
 impl<'a> Vertex<'a> {
+    /// Returns an iterator over the attributes in the vertex.
+    ///
+    /// # Examples
+    /// ```
+    /// # #![allow(unused_variables)]
+    /// # use std::fs::File;
+    /// # use collaborate::v1_4::*;
+    /// # let file = File::open("resources/blender_cube.dae").unwrap();
+    /// # let document = Collada::read(file).unwrap();
+    /// # let library = document.libraries[5].as_library_geometries().unwrap();
+    /// # let mesh = library.geometries[0].geometric_element.as_mesh().unwrap();
+    /// # let polylist = mesh.primitives[0].as_polylist().unwrap();
+    /// # let polygon = polylist.iter().next().unwrap();
+    /// let vertex = polygon.iter().next().unwrap();
+    /// let mut iter = vertex.iter();
+    /// assert_eq!(Some(VertexAttribute { index: 0, offset: 0 }), iter.next());
+    /// assert_eq!(Some(VertexAttribute { index: 0, offset: 1 }), iter.next());
+    /// assert_eq!(None, iter.next());
+    /// ```
     pub fn iter(&self) -> VertexIter<'a> {
         VertexIter {
             iter: self.attributes.iter(),

--- a/tests/v1_4.rs
+++ b/tests/v1_4.rs
@@ -420,135 +420,65 @@ fn polylist_iter() {
 
     let mut polygons = polylist.iter();
 
+    // Check first polygon.
     {
         let polygon = polygons.next().unwrap();
         assert_eq!(3, polygon.len());
 
-        let mut vertices = polygon.vertices();
-        assert_eq!(Some([0, 0].as_ref()), vertices.next());
-        assert_eq!(Some([2, 0].as_ref()), vertices.next());
-        assert_eq!(Some([3, 0].as_ref()), vertices.next());
+        let mut vertices = polygon.iter();
+
+        {
+            let mut vertex = vertices.next().unwrap().iter();
+            assert_eq!(Some(VertexAttribute { index: 0, offset: 0 }), vertex.next());
+            assert_eq!(Some(VertexAttribute { index: 0, offset: 1 }), vertex.next());
+            assert_eq!(None, vertex.next());
+        }
+
+        {
+            let mut vertex = vertices.next().unwrap().iter();
+            assert_eq!(Some(VertexAttribute { index: 2, offset: 0 }), vertex.next());
+            assert_eq!(Some(VertexAttribute { index: 0, offset: 1 }), vertex.next());
+            assert_eq!(None, vertex.next());
+        }
+
+        {
+            let mut vertex = vertices.next().unwrap().iter();
+            assert_eq!(Some(VertexAttribute { index: 3, offset: 0 }), vertex.next());
+            assert_eq!(Some(VertexAttribute { index: 0, offset: 1 }), vertex.next());
+            assert_eq!(None, vertex.next());
+        }
+
         assert_eq!(None, vertices.next());
     }
 
+    // Check last polygon.
     {
-        let polygon = polygons.next().unwrap();
+        let polygon = polygons.nth(10).unwrap();
         assert_eq!(3, polygon.len());
 
-        let mut vertices = polygon.vertices();
-        assert_eq!(Some([7, 1].as_ref()), vertices.next());
-        assert_eq!(Some([5, 1].as_ref()), vertices.next());
-        assert_eq!(Some([4, 1].as_ref()), vertices.next());
-        assert_eq!(None, vertices.next());
-    }
+        let mut vertices = polygon.iter();
 
-    {
-        let polygon = polygons.next().unwrap();
-        assert_eq!(3, polygon.len());
+        {
+            let mut vertex = vertices.next().unwrap().iter();
+            assert_eq!(Some(VertexAttribute { index: 0, offset: 0 }), vertex.next());
+            assert_eq!(Some(VertexAttribute { index: 11, offset: 1 }), vertex.next());
+            assert_eq!(None, vertex.next());
+        }
 
-        let mut vertices = polygon.vertices();
-        assert_eq!(Some([4, 2].as_ref()), vertices.next());
-        assert_eq!(Some([1, 2].as_ref()), vertices.next());
-        assert_eq!(Some([0, 2].as_ref()), vertices.next());
-        assert_eq!(None, vertices.next());
-    }
+        {
+            let mut vertex = vertices.next().unwrap().iter();
+            assert_eq!(Some(VertexAttribute { index: 3, offset: 0 }), vertex.next());
+            assert_eq!(Some(VertexAttribute { index: 11, offset: 1 }), vertex.next());
+            assert_eq!(None, vertex.next());
+        }
 
-    {
-        let polygon = polygons.next().unwrap();
-        assert_eq!(3, polygon.len());
+        {
+            let mut vertex = vertices.next().unwrap().iter();
+            assert_eq!(Some(VertexAttribute { index: 7, offset: 0 }), vertex.next());
+            assert_eq!(Some(VertexAttribute { index: 11, offset: 1 }), vertex.next());
+            assert_eq!(None, vertex.next());
+        }
 
-        let mut vertices = polygon.vertices();
-        assert_eq!(Some([5, 3].as_ref()), vertices.next());
-        assert_eq!(Some([2, 3].as_ref()), vertices.next());
-        assert_eq!(Some([1, 3].as_ref()), vertices.next());
-        assert_eq!(None, vertices.next());
-    }
-
-    {
-        let polygon = polygons.next().unwrap();
-        assert_eq!(3, polygon.len());
-
-        let mut vertices = polygon.vertices();
-        assert_eq!(Some([2, 4].as_ref()), vertices.next());
-        assert_eq!(Some([7, 4].as_ref()), vertices.next());
-        assert_eq!(Some([3, 4].as_ref()), vertices.next());
-        assert_eq!(None, vertices.next());
-    }
-
-    {
-        let polygon = polygons.next().unwrap();
-        assert_eq!(3, polygon.len());
-
-        let mut vertices = polygon.vertices();
-        assert_eq!(Some([0, 5].as_ref()), vertices.next());
-        assert_eq!(Some([7, 5].as_ref()), vertices.next());
-        assert_eq!(Some([4, 5].as_ref()), vertices.next());
-        assert_eq!(None, vertices.next());
-    }
-
-    {
-        let polygon = polygons.next().unwrap();
-        assert_eq!(3, polygon.len());
-
-        let mut vertices = polygon.vertices();
-        assert_eq!(Some([0, 6].as_ref()), vertices.next());
-        assert_eq!(Some([1, 6].as_ref()), vertices.next());
-        assert_eq!(Some([2, 6].as_ref()), vertices.next());
-        assert_eq!(None, vertices.next());
-    }
-
-    {
-        let polygon = polygons.next().unwrap();
-        assert_eq!(3, polygon.len());
-
-        let mut vertices = polygon.vertices();
-        assert_eq!(Some([7, 7].as_ref()), vertices.next());
-        assert_eq!(Some([6, 7].as_ref()), vertices.next());
-        assert_eq!(Some([5, 7].as_ref()), vertices.next());
-        assert_eq!(None, vertices.next());
-    }
-
-    {
-        let polygon = polygons.next().unwrap();
-        assert_eq!(3, polygon.len());
-
-        let mut vertices = polygon.vertices();
-        assert_eq!(Some([4, 8].as_ref()), vertices.next());
-        assert_eq!(Some([5, 8].as_ref()), vertices.next());
-        assert_eq!(Some([1, 8].as_ref()), vertices.next());
-        assert_eq!(None, vertices.next());
-    }
-
-    {
-        let polygon = polygons.next().unwrap();
-        assert_eq!(3, polygon.len());
-
-        let mut vertices = polygon.vertices();
-        assert_eq!(Some([5, 9].as_ref()), vertices.next());
-        assert_eq!(Some([6, 9].as_ref()), vertices.next());
-        assert_eq!(Some([2, 9].as_ref()), vertices.next());
-        assert_eq!(None, vertices.next());
-    }
-
-    {
-        let polygon = polygons.next().unwrap();
-        assert_eq!(3, polygon.len());
-
-        let mut vertices = polygon.vertices();
-        assert_eq!(Some([2, 10].as_ref()), vertices.next());
-        assert_eq!(Some([6, 10].as_ref()), vertices.next());
-        assert_eq!(Some([7, 10].as_ref()), vertices.next());
-        assert_eq!(None, vertices.next());
-    }
-
-    {
-        let polygon = polygons.next().unwrap();
-        assert_eq!(3, polygon.len());
-
-        let mut vertices = polygon.vertices();
-        assert_eq!(Some([0, 11].as_ref()), vertices.next());
-        assert_eq!(Some([3, 11].as_ref()), vertices.next());
-        assert_eq!(Some([7, 11].as_ref()), vertices.next());
         assert_eq!(None, vertices.next());
     }
 


### PR DESCRIPTION
I've added a new example `blender_cube` which shows how to extract position and normal data from a `<mesh>` with a `<polylist>`. In writing the example, I've added a number of helpers that make it easier to iterate over polygons, vertices, and vertex attributes. I've added documentation for these helpers, and the example shows how to extract mesh data from a real document.