### PR TITLE
Add libraries and geometries iterators

### DIFF
--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -114,6 +114,25 @@ impl Collada {
         Self::parse(reader)
     }
 
+    /// Returns an iterator over all the libraries in the document.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![allow(unused_variables)]
+    /// # use std::fs::File;
+    /// # use collaborate::v1_4::Collada;
+    /// # let file = File::open("resources/blender_cube.dae").unwrap();
+    /// let collada = Collada::read(file).unwrap();
+    /// for library in collada.libraries() {
+    ///     println!("Library: {:?}", library);
+    /// }
+    /// ```
+    ///
+    pub fn libraries<'a>(&'a self) -> ::std::slice::Iter<'a, Library> {
+        self.libraries.iter()
+    }
+
     /// Helper method that handles the bulk of the parsing work.
     ///
     /// `from_str` and `read` just create the `EventReader<R>` instance and then defer to `parse`.

--- a/src/v1_4.rs
+++ b/src/v1_4.rs
@@ -639,6 +639,15 @@ pub struct LibraryGeometries {
     pub extras: Vec<Extra>,
 }
 
+impl LibraryGeometries {
+    /// Returns an iterator over all the [`Geometry`] objects contained in this library.
+    ///
+    /// [`Geometry`]: ./struct.Geometry.html
+    pub fn geometries<'a>(&'a self) -> ::std::slice::Iter<'a, Geometry> {
+        self.geometries.iter()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, ColladaElement)]
 #[name = "library_images"]
 pub struct LibraryImages;


### PR DESCRIPTION
I've added helper methods to more succinctly iterate over all libraries in a document and all geometries in a `LibraryGeometries`.  This helps cut down on some boilerplate when iterating over the contents of a document.